### PR TITLE
Isoacoustic changes

### DIFF
--- a/stride/physics/iso_acoustic/devito.py
+++ b/stride/physics/iso_acoustic/devito.py
@@ -463,7 +463,7 @@ class IsoAcousticDevito(ProblemTypeBase):
             self.wavefield = None
 
         traces_data = np.asarray(self.dev_grid.vars.rec.data, dtype=np.float32).T
-        traces = shot.observed.alike(name='modelled', data=traces_data)
+        traces = shot.observed.alike(name='modelled', data=traces_data, shape=None, extended_shape=None, inner=None)
 
         self.boundary.deallocate()
         self.dev_grid.deallocate('p')
@@ -915,7 +915,21 @@ class IsoAcousticDevito(ProblemTypeBase):
 
         # Figure out propagated bandwidth
         wavelets = wavelets.data
-        f_min, f_centre, f_max = fft.bandwidth(wavelets, self.time.step, cutoff=-10)
+        if wavelets.ndim > 1:
+            f_mins = []
+            f_centres = []
+            f_maxs = []
+            for i in range(wavelets.shape[0]):
+                if np.any(wavelets[i]):
+                    # only run calculations on non-zero wavelets
+                    f_min, f_centre, f_max = fft.bandwidth(wavelets[i], self.time.step, cutoff=-10)
+                    f_mins.append(f_min)
+                    f_centres.append(f_centre)
+                    f_maxs.append(f_max)
+
+            f_min = np.min(f_mins)
+            f_max = np.max(f_maxs)
+            f_centre = np.median(f_centres)
 
         self._bandwidth = (f_min, f_centre, f_max)
 

--- a/stride/physics/iso_acoustic/devito.py
+++ b/stride/physics/iso_acoustic/devito.py
@@ -225,8 +225,8 @@ class IsoAcousticDevito(ProblemTypeBase):
 
         self._check_problem(wavelets, vp, rho=rho, alpha=alpha, **kwargs)
 
-        num_sources = shot.num_sources
-        num_receivers = shot.num_receivers
+        num_sources = shot.num_points_sources
+        num_receivers = shot.num_points_receivers
 
         save_wavefield = kwargs.get('save_wavefield', False)
         if save_wavefield is False:
@@ -507,8 +507,8 @@ class IsoAcousticDevito(ProblemTypeBase):
         problem = kwargs.get('problem')
         shot = problem.shot
 
-        num_sources = shot.num_sources
-        num_receivers = shot.num_receivers
+        num_sources = shot.num_points_sources
+        num_receivers = shot.num_points_receivers
 
         # If there's no previous operator, generate one
         if self.adjoint_operator.devito_operator is None:

--- a/stride/physics/iso_elastic/devito.py
+++ b/stride/physics/iso_elastic/devito.py
@@ -107,8 +107,8 @@ class IsoElasticDevito(ProblemTypeBase):
         problem = kwargs.get('problem')
         shot = problem.shot
 
-        num_sources = shot.num_sources
-        num_receivers = shot.num_receivers
+        num_sources = shot.num_points_sources
+        num_receivers = shot.num_points_receivers
 
         # If there's no previous operator, generate one
         if self.state_operator.devito_operator is None:

--- a/stride/problem/acquisitions.py
+++ b/stride/problem/acquisitions.py
@@ -223,9 +223,25 @@ class Shot(ProblemBase):
         return len(self.source_ids)
 
     @property
+    def num_points_sources(self):
+        """
+        Get total number of point sources in the Shot.
+
+        """
+        return len(self.source_ids)
+
+    @property
     def num_receivers(self):
         """
         Get number of receivers in the Shot.
+
+        """
+        return len(self.receiver_ids)
+
+    @property
+    def num_points_receivers(self):
+        """
+        Get total number of point receivers in the Shot.
 
         """
         return len(self.receiver_ids)


### PR DESCRIPTION
### Changes

- Addition of `num_point_sources()` and `num_point_receivers ()` to `Shot` class for future flexibility. While only point sources are available, the behaviour is the same as the existing `num_sources()` and `num_receivers()` methods. `IsoAcousticDevito` class updated to use these new methods in `before_forward()` and `before_adjoint()`.
- Removed constraint for `traces` in `after_forward()` of `IsoAcousticDevito` to be the same shape as `shot.observed`.
- Bandwidth estimation in `_check_conditions()` of `IsoAcousticDevito` class changed to handle multiple wavelets in a shot.