### PR TITLE
Adding conditional to uvloop installation so that stride can be installed on Windows

### DIFF
--- a/mosaic/utils/event_loop.py
+++ b/mosaic/utils/event_loop.py
@@ -1,6 +1,5 @@
 
 import uuid
-import uvloop
 import asyncio
 import inspect
 import weakref
@@ -173,7 +172,12 @@ class EventLoop:
     """
 
     def __init__(self, loop=None):
-        uvloop.install()
+        try:
+            import uvloop
+            uvloop.install()
+        except ImportError:
+            pass
+
         self._loop = loop or asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ scikit-image
 scipy>=1.6
 sphinx
 sphinx_rtd_theme
-uvloop
+uvloop; platform_system != "Windows"
 zict>=3.0.0


### PR DESCRIPTION
This PR is meant to allow Windows users to install and use Stride by adding a conditional to the `requirements.txt`, which will make pip skip the uvloop installation.

Stride installation error on Windows:
```
Collecting uvloop (from stride==1.2)
  Downloading uvloop-0.17.0.tar.gz (2.3 MB)
     ---------------------------------------- 2.3/2.3 MB 36.6 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  python setup.py egg_info did not run successfully.
  exit code: 1
  
  [6 lines of output]
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-install-ox6mokqg\uvloop_b71853bab3a84[70]
    ...
    , line 8, in <module>
Error:       raise RuntimeError('uvloop does not support Windows at the moment')
```

