### PR TITLE
remove redundant assignments, lift sources_uids

### DIFF
--- a/stride/utils/fullwave.py
+++ b/stride/utils/fullwave.py
@@ -156,16 +156,15 @@ def read_observed_ttr(ttr_path, store_traces=True):
                 row = struct.unpack('<iii' + nt*'f' + 'i', row)
 
                 csref = row[1] - 1    # Fullwave starts count from 1, stride from 0
-                rcvref = row[2] - 1   # Fullwave starts count from 1, stride from 0
-                trace = np.array(row[3:-1], dtype=np.float32)
 
                 # Append shot id
                 sources_ids.append(csref)
-                sources_uids = list(set(sources_ids))  # unique source ids only
 
             except struct.error as e:
                 mosaic.logger().warn("Warning: Line %g of %s file could not be "
                                       "unpacked" % (cnt, ttr_path.split("/")[-1]))
+
+    sources_uids = list(set(sources_ids))  # unique source ids only
 
     with open(ttr_path, mode='rb') as file:
 


### PR DESCRIPTION
I was running into a memory issue in the first while loop of the `read_observed_ttr()` function. I have removed the following variable assignments which are redundant and result in unnecessary memory allocation: 

```
rcvref = row[2] - 1   # Fullwave starts count from 1, stride from 0
trace = np.array(row[3:-1], dtype=np.float32)
```

Importantly, I have also lifted `sources_uids = list(set(sources_ids))  # unique source ids only` to outside and after the first while loop, as it results in unnecessary and progressively growing memory allocations throughout the loop as the `source_ids` list grows.

I would greatly appreciate someone reviewing and approving these changes if they make sense and won't cause any other unwanted side effects (I may have missed something). 