### PR TITLE
Cloud infra 1: inverse handshake and instance IDs

### DIFF
--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -30,7 +30,9 @@ def init(runtime_type='head', runtime_indices=(),
          num_workers=1, num_threads=None,
          mode='local', reuse_head=False, monitor_strategy='round-robin',
          log_level='perf', profile=False, node_list=None,
+         phone_home=False, timeout=None, 
          asyncio_loop=None, dump_init=False, wait=False,
+         runtime_uid=None, local_warehouse_uid=None,
          **kwargs):
     """
     Starts the global mosaic runtime.
@@ -61,11 +63,13 @@ def init(runtime_type='head', runtime_indices=(),
         Publishing port of the monitor to connect to.
     num_workers : int, optional
         Number of workers to instantiate in each node, defaults to 1.
+        In dynamic mode, this is the minimum number of workers to wait for.
     num_threads : int, optional
         Number of threads to assign to each worker, defaults to the number of
         available cores over ``num_workers``.
     mode : str, optional
-        Mode of the runtime, defaults to ``local``.
+        Mode of the runtime: ``local``, ``cluster``, or ``dynamic``.
+        In ``dynamic`` mode, the monitor waits for nodes to phone home.
     reuse_head : bool, optional
         Whether to set up workers in the head node, defaults to False.
     monitor_strategy : str, optional
@@ -76,6 +80,11 @@ def init(runtime_type='head', runtime_indices=(),
         Whether to start the profiler, defaults to False.
     node_list : list, optional
         List of available node addresses to connect to.
+    phone_home : bool, optional
+        If True, read monitor address from MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT
+        environment variables and connect to the monitor (phone-home mode).
+    timeout : float, optional
+        Timeout in seconds for waiting for workers to connect.
     asyncio_loop: object, optional
         Async loop to use in our mosaic event loop, defaults to new loop.
     dump_init : bool, optional
@@ -98,6 +107,7 @@ def init(runtime_type='head', runtime_indices=(),
 
     runtime_config = {
         'runtime_indices': runtime_indices,
+        'runtime_uid': runtime_uid,
         'mode': mode,
         'reuse_head': reuse_head,
         'monitor_strategy': monitor_strategy,
@@ -106,11 +116,20 @@ def init(runtime_type='head', runtime_indices=(),
         'log_level': log_level,
         'profile': profile,
         'node_list': node_list,
+        'phone_home': phone_home,
         'dump_init': dump_init,
     }
 
-    if address is not None and port is not None:
+    if local_warehouse_uid is not None:
+        runtime_config['local_warehouse_uid'] = local_warehouse_uid
+    
+    if timeout is not None:
+        runtime_config['timeout'] = timeout
+
+    if address is not None:
         runtime_config['address'] = address
+
+    if port is not None:
         runtime_config['port'] = port
 
     if parent_id is not None and parent_address is not None and parent_port is not None:

--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -30,7 +30,7 @@ def init(runtime_type='head', runtime_indices=(),
          num_workers=1, num_threads=None,
          mode='local', reuse_head=False, monitor_strategy='round-robin',
          log_level='perf', profile=False, node_list=None,
-         phone_home=False, timeout=None, 
+         timeout=None,
          asyncio_loop=None, dump_init=False, wait=False,
          runtime_uid=None, local_warehouse_uid=None,
          **kwargs):
@@ -69,7 +69,10 @@ def init(runtime_type='head', runtime_indices=(),
         available cores over ``num_workers``.
     mode : str, optional
         Mode of the runtime: ``local``, ``cluster``, or ``dynamic``.
-        In ``dynamic`` mode, the monitor waits for nodes to phone home.
+        In ``dynamic`` mode, the monitor waits for nodes to connect at
+        runtime and nodes read the monitor's address from
+        ``MOSAIC_MONITOR_HOST``, ``MOSAIC_MONITOR_PORT`` and
+        ``MOSAIC_PUBSUB_PORT`` environment variables.
     reuse_head : bool, optional
         Whether to set up workers in the head node, defaults to False.
     monitor_strategy : str, optional
@@ -80,9 +83,6 @@ def init(runtime_type='head', runtime_indices=(),
         Whether to start the profiler, defaults to False.
     node_list : list, optional
         List of available node addresses to connect to.
-    phone_home : bool, optional
-        If True, read monitor address from MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT
-        environment variables and connect to the monitor (phone-home mode).
     timeout : float, optional
         Timeout in seconds for waiting for workers to connect.
     asyncio_loop: object, optional
@@ -91,6 +91,10 @@ def init(runtime_type='head', runtime_indices=(),
         Whether to dump initialisation file.
     wait : bool, optional
         Whether or not to return control to calling frame, defaults to False.
+    runtime_uid : str, optional
+        Explicit UID for this runtime; overrides the index-derived default.
+    local_warehouse_uid : str, optional
+        UID of the warehouse to use as this runtime's local warehouse.
     kwargs : optional
         Extra keyword arguments.
 
@@ -116,7 +120,6 @@ def init(runtime_type='head', runtime_indices=(),
         'log_level': log_level,
         'profile': profile,
         'node_list': node_list,
-        'phone_home': phone_home,
         'dump_init': dump_init,
     }
 

--- a/mosaic/cli/mrun.py
+++ b/mosaic/cli/mrun.py
@@ -49,7 +49,6 @@ from ..utils.logger import _stdout, _stderr
               help='run monitor in dynamic mode, waiting for nodes to phone home')
 @click.option('--phone-home', is_flag=True, default=False, show_default=True,
               help='connect to monitor address from MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT env vars')
-
 # log level
 @click.option('--perf', 'log_level', flag_value='perf', default='perf', show_default=True,
               help='set log level to PERF')
@@ -67,7 +66,7 @@ def go(cmd=None, **kwargs):
     runtime_type = kwargs.get('runtime_type', None)
     runtime_indices = kwargs.get('indices', None)
     local = kwargs.get('local', False)
-    dynamic = kwargs.get('dynamic', False)  
+    dynamic = kwargs.get('dynamic', False)
     phone_home = kwargs.get('phone_home', False)
     reuse_head = kwargs.get('reuse_head', False)
 
@@ -110,10 +109,10 @@ def go(cmd=None, **kwargs):
 
         if node_list is not None and num_nodes != len(node_list):
             node_list = node_list[:num_nodes]
-    
+
     if local:
         mode = 'local'
-    elif dynamic: 
+    elif dynamic:
         mode = 'dynamic'
     else:
         mode = 'cluster'

--- a/mosaic/cli/mrun.py
+++ b/mosaic/cli/mrun.py
@@ -45,6 +45,11 @@ from ..utils.logger import _stdout, _stderr
               help='whether to run mosaic locally or in a cluster system')
 @click.option('--reuse-head/--free-head', '-rh/-fh', default=False, required=True, show_default=True,
               help='whether to create workers in the head node')
+@click.option('--dynamic', is_flag=True, default=False, show_default=True,
+              help='run monitor in dynamic mode, waiting for nodes to phone home')
+@click.option('--phone-home', is_flag=True, default=False, show_default=True,
+              help='connect to monitor address from MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT env vars')
+
 # log level
 @click.option('--perf', 'log_level', flag_value='perf', default='perf', show_default=True,
               help='set log level to PERF')
@@ -62,6 +67,8 @@ def go(cmd=None, **kwargs):
     runtime_type = kwargs.get('runtime_type', None)
     runtime_indices = kwargs.get('indices', None)
     local = kwargs.get('local', False)
+    dynamic = kwargs.get('dynamic', False)  
+    phone_home = kwargs.get('phone_home', False)
     reuse_head = kwargs.get('reuse_head', False)
 
     if runtime_indices is not None:
@@ -103,6 +110,13 @@ def go(cmd=None, **kwargs):
 
         if node_list is not None and num_nodes != len(node_list):
             node_list = node_list[:num_nodes]
+    
+    if local:
+        mode = 'local'
+    elif dynamic: 
+        mode = 'dynamic'
+    else:
+        mode = 'cluster'
 
     runtime_config = {
         'runtime_indices': runtime_indices,
@@ -114,11 +128,12 @@ def go(cmd=None, **kwargs):
         'num_nodes': num_nodes,
         'num_workers': num_workers,
         'num_threads': num_threads,
-        'mode': 'local' if local is True else 'cluster',
+        'mode': mode,
         'reuse_head': reuse_head,
         'log_level': log_level,
         'profile': profile,
         'node_list': node_list,
+        'phone_home': phone_home
     }
 
     # Initialise the runtime

--- a/mosaic/cli/mrun.py
+++ b/mosaic/cli/mrun.py
@@ -46,9 +46,7 @@ from ..utils.logger import _stdout, _stderr
 @click.option('--reuse-head/--free-head', '-rh/-fh', default=False, required=True, show_default=True,
               help='whether to create workers in the head node')
 @click.option('--dynamic', is_flag=True, default=False, show_default=True,
-              help='run monitor in dynamic mode, waiting for nodes to phone home')
-@click.option('--phone-home', is_flag=True, default=False, show_default=True,
-              help='connect to monitor address from MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT env vars')
+              help='enable dynamic mode (monitor waits for nodes; nodes read monitor address from env vars)')
 # log level
 @click.option('--perf', 'log_level', flag_value='perf', default='perf', show_default=True,
               help='set log level to PERF')
@@ -67,7 +65,6 @@ def go(cmd=None, **kwargs):
     runtime_indices = kwargs.get('indices', None)
     local = kwargs.get('local', False)
     dynamic = kwargs.get('dynamic', False)
-    phone_home = kwargs.get('phone_home', False)
     reuse_head = kwargs.get('reuse_head', False)
 
     if runtime_indices is not None:
@@ -132,7 +129,6 @@ def go(cmd=None, **kwargs):
         'log_level': log_level,
         'profile': profile,
         'node_list': node_list,
-        'phone_home': phone_home
     }
 
     # Initialise the runtime

--- a/mosaic/comms/comms.py
+++ b/mosaic/comms/comms.py
@@ -408,7 +408,7 @@ class InboundConnection(Connection):
                     s.close()
             except OSError:
                 pass
-            
+
             # Now fall back to hostname
             if self._address is None:
                 self._address = get_hostname()
@@ -2261,8 +2261,8 @@ class CommsManager:
         """
         Start handshake with remote ``uid``, located at a certain ``address`` and ``port``.
 
-        Sends a ``hand`` and waits for a ``shake`` reply. 
-        The recv task persists across retries (pyzmq loses messages on cancellation). 
+        Sends a ``hand`` and waits for a ``shake`` reply.
+        The recv task persists across retries (pyzmq loses messages on cancellation).
         Messages arriving before the shake completes are buffered and dispatched afterwards.
 
         Parameters
@@ -2298,7 +2298,7 @@ class CommsManager:
         await self.send_async(uid,
                               method='hand',
                               address=self.address, port=self.port)
-        
+
         # Buffer any RPC messages that arrive before the shake completed
         pending = []
 
@@ -2313,14 +2313,14 @@ class CommsManager:
                                           method='hand',
                                           address=self.address, port=self.port)
                     continue
-                
+
                 sender_id, response = recv_task.result()
 
                 if uid == sender_id and response.method == 'shake':
                     break
                 elif response.method not in ('shake', 'hand', 'reply'):
                     pending.append((sender_id, response))
-                
+
                 # Message processed, start waiting for the next one
                 recv_task = asyncio.ensure_future(self.recv_async())
         finally:
@@ -2362,13 +2362,13 @@ class CommsManager:
         """
         if self._state == 'disconnected':
             return
-        
+
         existing = self._send_conn.get(sender_id)
 
         # Cleanup stale socket
         if existing is not None and existing.state == 'connected':
             existing.disconnect()
-        
+
         self.connect_send(sender_id, address, port)
 
         # zmq.ROUTER messages will be dropped if endpoint not yet connected

--- a/mosaic/comms/comms.py
+++ b/mosaic/comms/comms.py
@@ -2325,7 +2325,7 @@ class CommsManager:
                 recv_task = asyncio.ensure_future(self.recv_async())
         finally:
             # Cleanup any pending messages
-            if not self.recv.done():
+            if not recv_task.done():
                 recv_task.cancel()
                 try:
                     await recv_task

--- a/mosaic/comms/comms.py
+++ b/mosaic/comms/comms.py
@@ -387,38 +387,35 @@ class InboundConnection(Connection):
     @property
     def address(self):
         """
-        Connection address.
+        Routable IP address for this connection.
 
-        If no address is set, it will try to discover it.
-
+        Auto-detects if not set or set to ``0.0.0.0`` (binding, non-routable).
+        Tries UDP probe first, then hostname, then localhost.
         """
-        if self._address is None:
-            # Try using a hostname first
-            self._address = get_hostname()
+        # 0.0.0.0 is valid for binding but not routable for pods in K8s - we need to auto-detect
+        if self._address is None or self._address == '0.0.0.0':
 
+            self._address = None
+
+            # Try to find routable IP via UDP probe first
             try:
-                validate_address(self._address)
-            except ValueError:
-                # Try to find an IP address otherwise
-                address, port = '8.8.8.8', '53'
                 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                address, port = '8.8.8.8', '53'
                 try:
-                    # This command will raise an exception if there is no internet
-                    # connection.
                     s.connect((address, int(port)))
                     self._address = s.getsockname()[0]
-                except OSError as e:
-                    self._address = '127.0.0.1'
-                    # [Errno 101] Network is unreachable
-                    if e.errno == errno.ENETUNREACH:
-                        try:
-                            # try get node ip address from host name
-                            host_name = get_hostname()
-                            self._address = socket.gethostbyname(host_name)
-                        except Exception:
-                            pass
                 finally:
                     s.close()
+            except OSError:
+                pass
+            
+            # Now fall back to hostname
+            if self._address is None:
+                self._address = get_hostname()
+                try:
+                    validate_address(self._address)
+                except ValueError:
+                    self._address = '127.0.0.1'
 
         return self._address
 
@@ -1531,6 +1528,9 @@ class CommsManager:
         Create and connect outbound connection for a remote runtime,
         with a given address and port.
 
+        If uid already has a connection but address changed,
+        the stale socket is torn down and replaced.
+
         Parameters
         ----------
         uid : str
@@ -1546,7 +1546,16 @@ class CommsManager:
         """
         validate_address(address, port)
 
-        if uid not in self._send_conn.keys() and uid != self._runtime.uid:
+        existing = self._send_conn.get(uid, None)
+        address_changed = existing is not None and (existing.address != address or existing.port != port)
+
+        # Create new connection if: first contact, previous died or address changed
+        if uid != self._runtime.uid and (existing is None or address_changed or existing.state == 'disconnected'):
+
+            # Tear down stale socket before new connection is made
+            if existing is not None and existing.state == 'connected':
+                existing.disconnect()
+
             self._send_conn[uid] = OutboundConnection(uid, address, port,
                                                       socket=self._send_socket,
                                                       runtime=self._runtime,
@@ -2242,7 +2251,7 @@ class CommsManager:
                                       method='disconnect',
                                       uid=uid)
 
-            if 'node' in uid and uid in self._runtime._nodes:
+            if uid.startswith('node:') and uid in self._runtime._nodes:
                 node_index = self._runtime._nodes[uid].indices[0]
                 for worker in self._runtime.workers:
                     if worker.indices[0] == node_index:
@@ -2251,6 +2260,10 @@ class CommsManager:
     async def handshake(self, uid, address, port, pubsub_port=None):
         """
         Start handshake with remote ``uid``, located at a certain ``address`` and ``port``.
+
+        Sends a ``hand`` and waits for a ``shake`` reply. 
+        The recv task persists across retries (pyzmq loses messages on cancellation). 
+        Messages arriving before the shake completes are buffered and dispatched afterwards.
 
         Parameters
         ----------
@@ -2285,16 +2298,39 @@ class CommsManager:
         await self.send_async(uid,
                               method='hand',
                               address=self.address, port=self.port)
+        
+        # Buffer any RPC messages that arrive before the shake completed
+        pending = []
 
-        while True:
-            try:
-                sender_id, response = await asyncio.wait_for(self.recv_async(), timeout=60)
-                if (uid == sender_id and response.method == 'shake') or self.shaken(uid):
+        # Keep recv task alive across multiple handshakes to avoid lost messages and potential deadlocks
+        recv_task = asyncio.ensure_future(self.recv_async())
+        try:
+            while True:
+                done, _ = await asyncio.wait([recv_task], timeout=10)
+                if not done:
+                    # Timeout - retry hand keeping recv_task alive
+                    await self.send_async(uid,
+                                          method='hand',
+                                          address=self.address, port=self.port)
+                    continue
+                
+                sender_id, response = recv_task.result()
+
+                if uid == sender_id and response.method == 'shake':
                     break
-            except asyncio.TimeoutError:
-                await self.send_async(uid,
-                                      method='hand',
-                                      address=self.address, port=self.port)
+                elif response.method not in ('shake', 'hand', 'reply'):
+                    pending.append((sender_id, response))
+                
+                # Message processed, start waiting for the next one
+                recv_task = asyncio.ensure_future(self.recv_async())
+        finally:
+            # Cleanup any pending messages
+            if not self.recv.done():
+                recv_task.cancel()
+                try:
+                    await recv_task
+                except (asyncio.CancelledError, Exception):
+                    pass
 
         self._send_conn[uid].shake()
         if pubsub_port is not None:
@@ -2302,6 +2338,10 @@ class CommsManager:
 
         await self.shake(sender_id, **response.kwargs)
         await self._loop.run(self._runtime.shake, sender_id, **response.kwargs)
+
+        # Dispatch any pending messages that arrived before the shake completed
+        for buffer_sender_id, buffer_response in pending:
+            await self.process_msg(buffer_sender_id, buffer_response)
 
     async def hand(self, sender_id, address, port):
         """
@@ -2322,7 +2362,13 @@ class CommsManager:
         """
         if self._state == 'disconnected':
             return
+        
+        existing = self._send_conn.get(sender_id)
 
+        # Cleanup stale socket
+        if existing is not None and existing.state == 'connected':
+            existing.disconnect()
+        
         self.connect_send(sender_id, address, port)
 
         # zmq.ROUTER messages will be dropped if endpoint not yet connected
@@ -2331,7 +2377,9 @@ class CommsManager:
         network = {}
         if self._runtime.uid == 'monitor':
             for connected_id, connection in self._send_conn.items():
-                network[connected_id] = (connection.address, connection.port)
+                # Only include live connections
+                if connection.state == 'connected':
+                    network[connected_id] = (connection.address, connection.port)
 
         await self.send_async(sender_id,
                               method='shake',

--- a/mosaic/comms/comms.py
+++ b/mosaic/comms/comms.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 import uuid
@@ -6,7 +5,6 @@ import asyncio
 import zmq
 import zmq.asyncio
 import tblib
-import errno
 import psutil
 import socket
 import warnings
@@ -62,6 +60,45 @@ def validate_address(address, port=False):
 
 def get_hostname():
     return socket.getfqdn(socket.gethostname())
+
+
+def discover_routable_address(current=None):
+    """
+    Return a routable IP address for binding/advertising.
+
+    Discovery order:
+      1. Hostname — used if ``validate_address`` accepts it (either an IP
+         literal or resolvable via DNS).
+      2. UDP probe to a public IP - picks the outgoing interface address.
+      3. Explicit DNS lookup of the hostname — last resort when the probe
+         also fails.
+      4. ``127.0.0.1`` if everything fails.
+
+    """
+    if current is not None and current != '0.0.0.0':
+        return current
+
+    # Try the hostname first
+    address = get_hostname()
+    try:
+        validate_address(address)
+    except ValueError:
+        # Hostname not usable — fall through to UDP probe
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                s.connect(('8.8.8.8', 53))
+                address = s.getsockname()[0]
+            finally:
+                s.close()
+        except OSError:
+            address = '127.0.0.1'
+            try:
+                address = socket.gethostbyname(get_hostname())
+            except (socket.gaierror, OSError):
+                pass
+
+    return address
 
 
 class CMD:
@@ -390,33 +427,8 @@ class InboundConnection(Connection):
         Routable IP address for this connection.
 
         Auto-detects if not set or set to ``0.0.0.0`` (binding, non-routable).
-        Tries UDP probe first, then hostname, then localhost.
         """
-        # 0.0.0.0 is valid for binding but not routable for pods in K8s - we need to auto-detect
-        if self._address is None or self._address == '0.0.0.0':
-
-            self._address = None
-
-            # Try to find routable IP via UDP probe first
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                address, port = '8.8.8.8', '53'
-                try:
-                    s.connect((address, int(port)))
-                    self._address = s.getsockname()[0]
-                finally:
-                    s.close()
-            except OSError:
-                pass
-
-            # Now fall back to hostname
-            if self._address is None:
-                self._address = get_hostname()
-                try:
-                    validate_address(self._address)
-                except ValueError:
-                    self._address = '127.0.0.1'
-
+        self._address = discover_routable_address(self._address)
         return self._address
 
     def connect(self):
@@ -852,39 +864,11 @@ class Publication(Connection):
     @property
     def address(self):
         """
-        Connection address.
+        Routable IP address for this connection.
 
-        If no address is set, it will try to discover it.
-
+        Auto-detects if not set or set to ``0.0.0.0`` (binding, non-routable).
         """
-        if self._address is None:
-            # Try using a hostname first
-            self._address = get_hostname()
-
-            try:
-                validate_address(self._address)
-            except ValueError:
-                # Try to find an IP address otherwise
-                address, port = '8.8.8.8', '53'
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                try:
-                    # This command will raise an exception if there is no internet
-                    # connection.
-                    s.connect((address, int(port)))
-                    self._address = s.getsockname()[0]
-                except OSError as e:
-                    self._address = '127.0.0.1'
-                    # [Errno 101] Network is unreachable
-                    if e.errno == errno.ENETUNREACH:
-                        try:
-                            # try get node ip address from host name
-                            host_name = get_hostname()
-                            self._address = socket.gethostbyname(host_name)
-                        except Exception:
-                            pass
-                finally:
-                    s.close()
-
+        self._address = discover_routable_address(self._address)
         return self._address
 
     def connect(self):
@@ -2251,7 +2235,7 @@ class CommsManager:
                                       method='disconnect',
                                       uid=uid)
 
-            if uid.startswith('node:') and uid in self._runtime._nodes:
+            if uid.startswith('node') and uid in self._runtime._nodes:
                 node_index = self._runtime._nodes[uid].indices[0]
                 for worker in self._runtime.workers:
                     if worker.indices[0] == node_index:

--- a/mosaic/runtime/head.py
+++ b/mosaic/runtime/head.py
@@ -65,9 +65,31 @@ class Head(Runtime):
         await super().init(**kwargs)
 
         # Wait for workers to be ready
+        num_workers = kwargs.pop('num_workers', 0)
+        timeout = kwargs.pop('timeout', 180)
+        if num_workers > 0:
+            await self.wait_for_workers(num_workers, timeout=timeout)
+
+    async def wait_for_workers(self, num_workers, timeout=180):
+        """
+        Wait for a specific number of workers to be available.
+
+        Useful in dynamic mode where workers connect at runtime.
+
+        Parameters
+        ----------
+        num_workers : int
+            Number of workers to wait for.
+        timeout : int or None
+            Maximum time to wait in seconds. If None, wait indefinitely.
+
+        Raises
+        -------
+        RuntimeError
+            If the specified number of workers do not connect within the timeout period.
+        
+        """
         tic = time.time()
-        num_workers = kwargs.pop('num_workers')
-        timeout = 180
         while len(self.workers) < num_workers:
             if timeout is not None and (time.time() - tic) > timeout:
                 raise RuntimeError('Timed out while waiting for %d workers to connect' % num_workers)

--- a/mosaic/runtime/head.py
+++ b/mosaic/runtime/head.py
@@ -87,7 +87,7 @@ class Head(Runtime):
         -------
         RuntimeError
             If the specified number of workers do not connect within the timeout period.
-        
+
         """
         tic = time.time()
         while len(self.workers) < num_workers:

--- a/mosaic/runtime/monitor.py
+++ b/mosaic/runtime/monitor.py
@@ -113,7 +113,8 @@ class Monitor(Runtime):
 
         if self.mode in ['local', 'interactive']:
             await self.init_local(**kwargs)
-
+        elif self.mode == 'dynamic':
+            await self.init_dynamic(**kwargs)
         else:
             await self.init_cluster(**kwargs)
 
@@ -241,6 +242,89 @@ class Monitor(Runtime):
                          'WORKER:0-%d address=%s>' % (0, num_nodes, num_workers,
                                                       ', '.join(node_list)))
 
+    async def init_dynamic(self, **kwargs):
+        """
+        Init in dynamic mode, waiting for nodes to phone-home.
+
+        In dynamic mode, the Monitor doesn't spawn nodes. Instead, it waits 
+        for nodes to connect independently. Nodes can be added at runtime
+        by starting them with the --phone-home flag.
+
+        Parameters
+        ----------
+        kwargs
+        
+        Returns
+        ----------
+
+        """
+        num_workers = kwargs.get('num_workers', 0)
+
+        self.logger.info('Waiting for nodes to phone home (dynamic mode)')
+
+        # Wait for at least the requested number of workers if specified
+        if num_workers > 0:
+            timeout = kwargs.pop('timeout', 300)
+            tic = time.time()
+            while self._get_total_workers() < num_workers:
+                if (time.time() - tic) > timeout:
+                    raise RuntimeError(f'Timed out while waiting for {num_workers} workers to phone home')
+                await asyncio.sleep(0.1)
+            
+            self.logger.debug(f'Dynamic mesh ready with {self._get_total_workers()} workers connected')
+
+    def _get_total_workers(self):
+        total = 0
+        for node in self._monitored_nodes.values():
+            if hasattr(node, 'sub_resources') and 'workers' in node.sub_resources:
+                total += len(node.sub_resources['workers'])
+        return total
+
+    @property
+    def num_workers(self):
+        return self._get_total_workers()
+    
+    @property
+    def workers(self):
+        result = []
+        for node in self._monitored_nodes.values():
+            if hasattr(node, 'sub_resources') and 'workers' in node.sub_resources:
+                for uid in node.sub_resources['workers']:
+                    result.append(RuntimeProxy(uid=uid))
+        return result
+                
+    async def register_node(self, sender_id, node_uid, num_workers):
+        """
+        Register a node that has phoned home in dynamic mode.
+
+        Parameters
+        ----------
+        sender_id : str
+        node_uid : str
+        num_workers : int
+
+        Returns
+        -------
+        dict[str, str]
+            Registration confirmation with status
+
+        """
+        if node_uid in self._nodes:
+            self.logger.info(f"Node {node_uid} already registered, ignoring duplicate phone home")
+            return {'status': 'already_registered'}
+
+        # Create proxy for the new node
+        node_proxy = RuntimeProxy(uid=node_uid)
+        node_proxy.subprocess = None  # No subprocess since we didn't spawn it
+
+        self._nodes[node_uid] = node_proxy
+        self.logger.info(f"Node {node_uid} registered with {num_workers} workers")
+
+        self._comms.start_heartbeat(node_uid)
+
+        return {'status': 'registered'}
+
+
     def init_file(self, runtime_config):
         runtime_id = self.uid
         runtime_address = self.address
@@ -306,8 +390,21 @@ class Monitor(Runtime):
     def update_node(self, sender_id, update, sub_resources):
         if sender_id in self._disconnected_runtimes:
             return
-        if sender_id not in self._monitored_nodes:
+
+        is_new_node = sender_id not in self._monitored_nodes
+        if is_new_node:
             self._monitored_nodes[sender_id] = MonitoredResource(sender_id)
+
+            if self.mode == 'dynamic':
+                self._comms.start_heartbeat(sender_id)
+                worker_ids = list(sub_resources.get('workers', {}).keys())
+                active_indices = set()
+                for uid in self._monitored_nodes:
+                    if uid not in self._disconnected_runtimes:
+                        parts = uid.split(':')
+                        active_indices.add(parts[1] if len(parts) > 2 else uid)
+                active_nodes = len(active_indices)
+                self.logger.info(f"Node {sender_id} connected with {len(worker_ids)} workers and {active_nodes} active nodes")
 
         node = self._monitored_nodes[sender_id]
         node.update(update, **sub_resources)

--- a/mosaic/runtime/monitor.py
+++ b/mosaic/runtime/monitor.py
@@ -260,7 +260,7 @@ class Monitor(Runtime):
         """
         num_workers = kwargs.get('num_workers', 0)
 
-        self.logger.info('Waiting for nodes to phone home (dynamic mode)')
+        self.logger.debug('Waiting for nodes to phone home (dynamic mode)')
 
         # Wait for at least the requested number of workers if specified
         if num_workers > 0:
@@ -292,37 +292,6 @@ class Monitor(Runtime):
                 for uid in node.sub_resources['workers']:
                     result.append(RuntimeProxy(uid=uid))
         return result
-
-    async def register_node(self, sender_id, node_uid, num_workers):
-        """
-        Register a node that has phoned home in dynamic mode.
-
-        Parameters
-        ----------
-        sender_id : str
-        node_uid : str
-        num_workers : int
-
-        Returns
-        -------
-        dict[str, str]
-            Registration confirmation with status
-
-        """
-        if node_uid in self._nodes:
-            self.logger.info(f"Node {node_uid} already registered, ignoring duplicate phone home")
-            return {'status': 'already_registered'}
-
-        # Create proxy for the new node
-        node_proxy = RuntimeProxy(uid=node_uid)
-        node_proxy.subprocess = None  # No subprocess since we didn't spawn it
-
-        self._nodes[node_uid] = node_proxy
-        self.logger.info(f"Node {node_uid} registered with {num_workers} workers")
-
-        self._comms.start_heartbeat(node_uid)
-
-        return {'status': 'registered'}
 
     def init_file(self, runtime_config):
         runtime_id = self.uid
@@ -402,8 +371,7 @@ class Monitor(Runtime):
                     if uid not in self._disconnected_runtimes:
                         parts = uid.split(':')
                         active_indices.add(parts[1] if len(parts) > 2 else uid)
-                active_nodes = len(active_indices)
-                self.logger.info(f"Node {sender_id} connected with {len(worker_ids)} workers and {active_nodes} active nodes")
+                self.logger.debug(f"Node {sender_id} connected with {len(worker_ids)} workers")
 
         node = self._monitored_nodes[sender_id]
         node.update(update, **sub_resources)

--- a/mosaic/runtime/monitor.py
+++ b/mosaic/runtime/monitor.py
@@ -246,14 +246,14 @@ class Monitor(Runtime):
         """
         Init in dynamic mode, waiting for nodes to phone-home.
 
-        In dynamic mode, the Monitor doesn't spawn nodes. Instead, it waits 
+        In dynamic mode, the Monitor doesn't spawn nodes. Instead, it waits
         for nodes to connect independently. Nodes can be added at runtime
         by starting them with the --phone-home flag.
 
         Parameters
         ----------
         kwargs
-        
+
         Returns
         ----------
 
@@ -270,7 +270,7 @@ class Monitor(Runtime):
                 if (time.time() - tic) > timeout:
                     raise RuntimeError(f'Timed out while waiting for {num_workers} workers to phone home')
                 await asyncio.sleep(0.1)
-            
+
             self.logger.debug(f'Dynamic mesh ready with {self._get_total_workers()} workers connected')
 
     def _get_total_workers(self):
@@ -283,7 +283,7 @@ class Monitor(Runtime):
     @property
     def num_workers(self):
         return self._get_total_workers()
-    
+
     @property
     def workers(self):
         result = []
@@ -292,7 +292,7 @@ class Monitor(Runtime):
                 for uid in node.sub_resources['workers']:
                     result.append(RuntimeProxy(uid=uid))
         return result
-                
+
     async def register_node(self, sender_id, node_uid, num_workers):
         """
         Register a node that has phoned home in dynamic mode.
@@ -323,7 +323,6 @@ class Monitor(Runtime):
         self._comms.start_heartbeat(node_uid)
 
         return {'status': 'registered'}
-
 
     def init_file(self, runtime_config):
         runtime_id = self.uid

--- a/mosaic/runtime/node.py
+++ b/mosaic/runtime/node.py
@@ -36,6 +36,8 @@ class Node(Runtime):
         self._num_workers = num_workers
         self._num_threads = None
         self._memory_limit = memory_limit()
+        self._instance_id = None
+        self._warehouse_uid = None
 
         self._monitored_node = MonitoredResource(self.uid)
         self._monitor_interval = None
@@ -181,9 +183,10 @@ class Node(Runtime):
                 kwargs.update(extra_kwargs)
                 kwargs['runtime_indices'] = indices
                 kwargs['runtime_uid'] = worker_uid
-                kwargs['local_warehouse_uid'] = self._warehouse_uid
                 kwargs['num_workers'] = num_workers
                 kwargs['num_threads'] = num_threads
+                if self._warehouse_uid is not None:
+                    kwargs['local_warehouse_uid'] = self._warehouse_uid
 
                 mosaic.init('worker', *args, **kwargs, wait=True)
 

--- a/mosaic/runtime/node.py
+++ b/mosaic/runtime/node.py
@@ -1,7 +1,6 @@
 
 import os
 import uuid
-
 import psutil
 
 import mosaic
@@ -37,7 +36,6 @@ class Node(Runtime):
         self._num_threads = None
         self._memory_limit = memory_limit()
         self._instance_id = None
-        self._warehouse_uid = None
 
         self._monitored_node = MonitoredResource(self.uid)
         self._monitor_interval = None
@@ -55,16 +53,16 @@ class Node(Runtime):
         -------
 
         """
-        # If phone-home mode is enabled, inject monitor address into kwargs
-        self._phone_home = kwargs.pop('phone_home', False)
-        if self._phone_home:
+        # In dynamic mode the node reads the monitor address from env vars
+        # rather than receiving it from a parent that spawned it
+        if self.mode == 'dynamic':
             self.init_phone_home(config=kwargs)
 
-        # Per-boot instance ID only in elastic environments where nodes can be replaced
-        # in local/cluster mode the monitor pre-allocates proxies by index-based UID
-        if self.mode == 'dynamic' or self._phone_home:
+            # Per-boot instance ID so a replacement at the same index doesn't
+            # collide with the dead pod's UIDs in the monitor's bookkeeping
             self._instance_id = uuid.uuid4().hex[:8]
-            self._uid_override = f'node:{self.indices[0]}:{self._instance_id}'
+            self._uid_override = self._build_uid(self._name, self._indices,
+                                                 self._instance_id)
 
         await super().init(**kwargs)
 
@@ -75,18 +73,18 @@ class Node(Runtime):
     def init_phone_home(self, config):
         """Read monitor address from environment variables and inject into kwargs.
 
-        Called when the node starts in phone-home mode.
-        The monitor's address, RPC port, and pub-sub port must be provided
-        via ``MONITOR_HOST``, ``MONITOR_PORT``, and ``PUBSUB_PORT``
-        environment variables.
+        Called when the node starts in dynamic mode. The monitor's address,
+        RPC port, and pub-sub port must be provided via ``MOSAIC_MONITOR_HOST``,
+        ``MOSAIC_MONITOR_PORT``, and ``MOSAIC_PUBSUB_PORT`` environment
+        variables.
         """
-        monitor_host = os.environ.get('MONITOR_HOST')
-        monitor_port = os.environ.get('MONITOR_PORT')
-        pubsub_port = os.environ.get('PUBSUB_PORT')
+        monitor_host = os.environ.get('MOSAIC_MONITOR_HOST')
+        monitor_port = os.environ.get('MOSAIC_MONITOR_PORT')
+        pubsub_port = os.environ.get('MOSAIC_PUBSUB_PORT')
         if not (monitor_host and monitor_port and pubsub_port):
             raise RuntimeError(
-                'phone_home=True but MONITOR_HOST, MONITOR_PORT, '
-                'and PUBSUB_PORT environment variables are not set'
+                'dynamic mode requires MOSAIC_MONITOR_HOST, MOSAIC_MONITOR_PORT '
+                'and MOSAIC_PUBSUB_PORT environment variables to be set'
             )
         config['monitor_address'] = monitor_host
         config['monitor_port'] = int(monitor_port)
@@ -178,12 +176,16 @@ class Node(Runtime):
         for worker_index in range(self._num_workers):
             indices = self.indices + (worker_index,)
 
-            if self._instance_id is not None:
-                worker_uid = f'worker:{self.indices[0]}:{worker_index}:{self._instance_id}'
-                worker_proxy = RuntimeProxy(name='worker', uid=worker_uid)
-            else:
-                worker_proxy = RuntimeProxy(name='worker', indices=indices)
-                worker_uid = worker_proxy.uid
+            worker_proxy = RuntimeProxy(name='worker', indices=indices,
+                                        instance_id=self._instance_id)
+            worker_uid = worker_proxy.uid
+
+            # Hoist into locals so start_worker's closure doesn't capture self
+            instance_id = self._instance_id
+            local_warehouse_uid = (
+                self._local_warehouse.uid
+                if self._local_warehouse is not None else None
+            )
 
             def start_worker(*args, **extra_kwargs):
                 kwargs.update(extra_kwargs)
@@ -191,10 +193,10 @@ class Node(Runtime):
                 kwargs['num_workers'] = num_workers
                 kwargs['num_threads'] = num_threads
 
-                if self._instance_id is not None:
+                if instance_id is not None:
                     kwargs['runtime_uid'] = worker_uid
-                if self._warehouse_uid is not None:
-                    kwargs['local_warehouse_uid'] = self._warehouse_uid
+                if local_warehouse_uid is not None:
+                    kwargs['local_warehouse_uid'] = local_warehouse_uid
 
                 mosaic.init('worker', *args, **kwargs, wait=True)
 

--- a/mosaic/runtime/node.py
+++ b/mosaic/runtime/node.py
@@ -1,4 +1,7 @@
 
+import os
+import uuid
+
 import psutil
 
 import mosaic
@@ -50,11 +53,41 @@ class Node(Runtime):
         -------
 
         """
+        # Generate a per-boot instance ID so every spawn of this node produces globally 
+        # unique runtime UIDs eliminating UID collisions in an elastic cluster environment
+        self._instance_id = uuid.uuid4().hex[:8]
+        self._uid_override = f'node:{self.indices[0]}:{self._instance_id}'
+
+        # If phone-home mode is enabled, inject monitor address into kwargs
+        self._phone_home = kwargs.pop('phone_home', False)
+        if self._phone_home:
+            self.init_phone_home(config=kwargs)
+
         await super().init(**kwargs)
 
         # Start local cluster
         await self.init_warehouse(indices=self.indices[0], **kwargs)
         await self.init_workers(**kwargs)
+
+    def init_phone_home(self, config):
+            """Read monitor address from environment variables and inject into kwargs.
+
+            Called when the node starts in phone-home mode.
+            The monitor's address, RPC port, and pub-sub port must be provided
+            via ``MONITOR_HOST``, ``MONITOR_PORT``, and ``PUBSUB_PORT``
+            environment variables.
+            """
+            monitor_host = os.environ.get('MONITOR_HOST')
+            monitor_port = os.environ.get('MONITOR_PORT')
+            pubsub_port = os.environ.get('PUBSUB_PORT')
+            if not (monitor_host and monitor_port and pubsub_port):
+                raise RuntimeError(
+                    'phone_home=True but MONITOR_HOST, MONITOR_PORT, '
+                    'and PUBSUB_PORT environment variables are not set'
+                )
+            config['monitor_address'] = monitor_host
+            config['monitor_port'] = int(monitor_port)
+            config['pubsub_port'] = int(pubsub_port)
 
     async def init_workers(self, **kwargs):
         """
@@ -142,15 +175,19 @@ class Node(Runtime):
         for worker_index in range(self._num_workers):
             indices = self.indices + (worker_index,)
 
+            worker_uid = f'worker:{self.indices[0]}:{worker_index}:{self._instance_id}'
+
             def start_worker(*args, **extra_kwargs):
                 kwargs.update(extra_kwargs)
                 kwargs['runtime_indices'] = indices
+                kwargs['runtime_uid'] = worker_uid
+                kwargs['local_warehouse_uid'] = self._warehouse_uid
                 kwargs['num_workers'] = num_workers
                 kwargs['num_threads'] = num_threads
 
                 mosaic.init('worker', *args, **kwargs, wait=True)
 
-            worker_proxy = RuntimeProxy(name='worker', indices=indices)
+            worker_proxy = RuntimeProxy(name='worker', uid=worker_uid)
             worker_subprocess = subprocess(start_worker)(name=worker_proxy.uid,
                                                          daemon=False,
                                                          cpu_affinity=worker_cpus.get(worker_index, None))

--- a/mosaic/runtime/node.py
+++ b/mosaic/runtime/node.py
@@ -55,15 +55,16 @@ class Node(Runtime):
         -------
 
         """
-        # Generate a per-boot instance ID so every spawn of this node produces globally
-        # unique runtime UIDs eliminating UID collisions in an elastic cluster environment
-        self._instance_id = uuid.uuid4().hex[:8]
-        self._uid_override = f'node:{self.indices[0]}:{self._instance_id}'
-
         # If phone-home mode is enabled, inject monitor address into kwargs
         self._phone_home = kwargs.pop('phone_home', False)
         if self._phone_home:
             self.init_phone_home(config=kwargs)
+
+        # Per-boot instance ID only in elastic environments where nodes can be replaced
+        # in local/cluster mode the monitor pre-allocates proxies by index-based UID
+        if self.mode == 'dynamic' or self._phone_home:
+            self._instance_id = uuid.uuid4().hex[:8]
+            self._uid_override = f'node:{self.indices[0]}:{self._instance_id}'
 
         await super().init(**kwargs)
 
@@ -177,20 +178,26 @@ class Node(Runtime):
         for worker_index in range(self._num_workers):
             indices = self.indices + (worker_index,)
 
-            worker_uid = f'worker:{self.indices[0]}:{worker_index}:{self._instance_id}'
+            if self._instance_id is not None:
+                worker_uid = f'worker:{self.indices[0]}:{worker_index}:{self._instance_id}'
+                worker_proxy = RuntimeProxy(name='worker', uid=worker_uid)
+            else:
+                worker_proxy = RuntimeProxy(name='worker', indices=indices)
+                worker_uid = worker_proxy.uid
 
             def start_worker(*args, **extra_kwargs):
                 kwargs.update(extra_kwargs)
                 kwargs['runtime_indices'] = indices
-                kwargs['runtime_uid'] = worker_uid
                 kwargs['num_workers'] = num_workers
                 kwargs['num_threads'] = num_threads
+
+                if self._instance_id is not None:
+                    kwargs['runtime_uid'] = worker_uid
                 if self._warehouse_uid is not None:
                     kwargs['local_warehouse_uid'] = self._warehouse_uid
 
                 mosaic.init('worker', *args, **kwargs, wait=True)
 
-            worker_proxy = RuntimeProxy(name='worker', uid=worker_uid)
             worker_subprocess = subprocess(start_worker)(name=worker_proxy.uid,
                                                          daemon=False,
                                                          cpu_affinity=worker_cpus.get(worker_index, None))

--- a/mosaic/runtime/node.py
+++ b/mosaic/runtime/node.py
@@ -53,7 +53,7 @@ class Node(Runtime):
         -------
 
         """
-        # Generate a per-boot instance ID so every spawn of this node produces globally 
+        # Generate a per-boot instance ID so every spawn of this node produces globally
         # unique runtime UIDs eliminating UID collisions in an elastic cluster environment
         self._instance_id = uuid.uuid4().hex[:8]
         self._uid_override = f'node:{self.indices[0]}:{self._instance_id}'
@@ -70,24 +70,24 @@ class Node(Runtime):
         await self.init_workers(**kwargs)
 
     def init_phone_home(self, config):
-            """Read monitor address from environment variables and inject into kwargs.
+        """Read monitor address from environment variables and inject into kwargs.
 
-            Called when the node starts in phone-home mode.
-            The monitor's address, RPC port, and pub-sub port must be provided
-            via ``MONITOR_HOST``, ``MONITOR_PORT``, and ``PUBSUB_PORT``
-            environment variables.
-            """
-            monitor_host = os.environ.get('MONITOR_HOST')
-            monitor_port = os.environ.get('MONITOR_PORT')
-            pubsub_port = os.environ.get('PUBSUB_PORT')
-            if not (monitor_host and monitor_port and pubsub_port):
-                raise RuntimeError(
-                    'phone_home=True but MONITOR_HOST, MONITOR_PORT, '
-                    'and PUBSUB_PORT environment variables are not set'
-                )
-            config['monitor_address'] = monitor_host
-            config['monitor_port'] = int(monitor_port)
-            config['pubsub_port'] = int(pubsub_port)
+        Called when the node starts in phone-home mode.
+        The monitor's address, RPC port, and pub-sub port must be provided
+        via ``MONITOR_HOST``, ``MONITOR_PORT``, and ``PUBSUB_PORT``
+        environment variables.
+        """
+        monitor_host = os.environ.get('MONITOR_HOST')
+        monitor_port = os.environ.get('MONITOR_PORT')
+        pubsub_port = os.environ.get('PUBSUB_PORT')
+        if not (monitor_host and monitor_port and pubsub_port):
+            raise RuntimeError(
+                'phone_home=True but MONITOR_HOST, MONITOR_PORT, '
+                'and PUBSUB_PORT environment variables are not set'
+            )
+        config['monitor_address'] = monitor_host
+        config['monitor_port'] = int(monitor_port)
+        config['pubsub_port'] = int(pubsub_port)
 
     async def init_workers(self, **kwargs):
         """

--- a/mosaic/runtime/runtime.py
+++ b/mosaic/runtime/runtime.py
@@ -110,7 +110,7 @@ class BaseRPC:
         """
         if self._uid_override is not None:
             return self._uid_override
-        
+
         if len(self.indices):
             indices = ':'.join([str(each) for each in self.indices])
             return '%s:%s' % (self.name, indices)

--- a/mosaic/runtime/runtime.py
+++ b/mosaic/runtime/runtime.py
@@ -42,6 +42,13 @@ class BaseRPC:
     A name ``runtime`` and indices ``(0, 0)`` will result in a UID ``runtime:0:0``,
     while the same name with no indices will result in a UID ``runtime``.
 
+    In dynamic mode (cloud deployment), UIDs include a per-boot instance ID to avoid
+    collisions when a node is replaced at the same index. For example,
+    ``worker:0:0:a3f7b2c1``. The instance ID is not part of the indices -
+    it is a non-numeric suffix. When a UID contains an instance ID, the
+    full string is stored as an override and returned via the
+    ``uid`` property.
+
     Parameters
     ----------
     name : str, optional
@@ -55,14 +62,18 @@ class BaseRPC:
     """
 
     def __init__(self, name=None, indices=(), uid=None):
+        self._uid_override = None
         if uid is not None:
-            uid = uid.split(':')
-            name = uid[0]
-
-            if len(uid) > 1:
-                indices = tuple([int(each) for each in uid[1:]])
-            else:
-                indices = ()
+            parts = uid.split(':')
+            name = parts[0]
+            indices = []
+            for part in parts[1:]:
+                if part.isdigit():
+                    indices.append(int(part))
+                else:
+                    self._uid_override = uid
+                    break
+            indices = tuple(indices)
 
         elif name is None:
             raise ValueError('Either name and indices or UID are required to instantiate the RPC')
@@ -97,6 +108,9 @@ class BaseRPC:
         Runtime UID.
 
         """
+        if self._uid_override is not None:
+            return self._uid_override
+        
         if len(self.indices):
             indices = ':'.join([str(each) for each in self.indices])
             return '%s:%s' % (self.name, indices)
@@ -142,8 +156,11 @@ class Runtime(BaseRPC):
     is_warehouse = False
 
     def __init__(self, **kwargs):
+        runtime_uid = kwargs.pop('runtime_uid', None)
         runtime_indices = kwargs.pop('runtime_indices', ())
         super().__init__(name=self.__class__.__name__.lower(), indices=runtime_indices)
+        if runtime_uid is not None:
+            self._uid_override = runtime_uid
 
         self.mode = kwargs.get('mode', 'local')
         self.reuse_head = kwargs.get('reuse_head', False)
@@ -185,7 +202,7 @@ class Runtime(BaseRPC):
 
         if self.uid == 'warehouse':
             self._mem_fraction = float(os.environ.get('MOSAIC_WAREHOUSE_MEM', 0.85))
-        elif 'worker' in self.uid:
+        elif self.uid.startswith('worker:'):
             self._mem_fraction = float(os.environ.get('MOSAIC_WORKER_MEM', 0.85))
         else:
             self._mem_fraction = float(os.environ.get('MOSAIC_RUNTIME_MEM', 0.85))
@@ -211,8 +228,11 @@ class Runtime(BaseRPC):
         self.set_logger()
 
         # Start warehouse
+        local_warehouse_uid = kwargs.pop('local_warehouse_uid', None)
         self._remote_warehouse = self.proxy('warehouse')
-        if len(self.indices):
+        if local_warehouse_uid is not None:
+            self._local_warehouse = self.proxy(uid=local_warehouse_uid)
+        elif len(self.indices):
             self._local_warehouse = self.proxy('warehouse', indices=self.indices[0])
         else:
             self._local_warehouse = self._remote_warehouse
@@ -264,7 +284,10 @@ class Runtime(BaseRPC):
 
         """
         warehouse_indices = kwargs.pop('indices', -1)
-        if warehouse_indices < 0:
+        warehouse_uid = kwargs.pop('uid', None)
+        if warehouse_uid is not None:
+            warehouse_proxy = RuntimeProxy(name='warehouse', uid=warehouse_uid)
+        elif warehouse_indices < 0:
             warehouse_proxy = RuntimeProxy(name='warehouse')
         else:
             warehouse_proxy = RuntimeProxy(name='warehouse', indices=warehouse_indices)
@@ -273,6 +296,8 @@ class Runtime(BaseRPC):
         def start_warehouse(*args, **extra_kwargs):
             kwargs.update(extra_kwargs)
             kwargs['runtime_indices'] = indices
+            if warehouse_uid is not None:
+                kwargs['runtime_uid'] = warehouse_uid
             mosaic.init('warehouse', *args, **kwargs, wait=True)
 
         warehouse_subprocess = subprocess(start_warehouse)(name=warehouse_proxy.uid, daemon=False)

--- a/mosaic/runtime/runtime.py
+++ b/mosaic/runtime/runtime.py
@@ -61,7 +61,7 @@ class BaseRPC:
 
     """
 
-    def __init__(self, name=None, indices=(), uid=None):
+    def __init__(self, name=None, indices=(), uid=None, instance_id=None):
         self._uid_override = None
         if uid is not None:
             parts = uid.split(':')
@@ -83,8 +83,19 @@ class BaseRPC:
         if type(indices) is not tuple:
             indices = (indices,)
 
+        if instance_id is not None:
+            self._uid_override = self._build_uid(name, indices, instance_id)
+
         self._name = name
         self._indices = indices
+
+    @staticmethod
+    def _build_uid(name, indices, instance_id=None):
+        """Construct a UID from a name, indices and an optional instance ID."""
+        parts = [name] + [str(i) for i in indices]
+        if instance_id is not None:
+            parts.append(instance_id)
+        return ':'.join(parts)
 
     @property
     def name(self):
@@ -111,12 +122,7 @@ class BaseRPC:
         if self._uid_override is not None:
             return self._uid_override
 
-        if len(self.indices):
-            indices = ':'.join([str(each) for each in self.indices])
-            return '%s:%s' % (self.name, indices)
-
-        else:
-            return self.name
+        return self._build_uid(self._name, self._indices)
 
     @property
     def address(self):
@@ -202,7 +208,7 @@ class Runtime(BaseRPC):
 
         if self.uid == 'warehouse':
             self._mem_fraction = float(os.environ.get('MOSAIC_WAREHOUSE_MEM', 0.85))
-        elif self.uid.startswith('worker:'):
+        elif self.uid.startswith('worker'):
             self._mem_fraction = float(os.environ.get('MOSAIC_WORKER_MEM', 0.85))
         else:
             self._mem_fraction = float(os.environ.get('MOSAIC_RUNTIME_MEM', 0.85))
@@ -1571,8 +1577,10 @@ class RuntimeProxy(BaseRPC):
 
     """
 
-    def __init__(self, name=None, indices=(), uid=None, comms=None):
-        super().__init__(name=name, indices=indices, uid=uid)
+    def __init__(self, name=None, indices=(), uid=None, comms=None,
+                 instance_id=None):
+        super().__init__(name=name, indices=indices, uid=uid,
+                         instance_id=instance_id)
 
         self._subprocess = None
 

--- a/mosaic/runtime/strategies.py
+++ b/mosaic/runtime/strategies.py
@@ -81,10 +81,30 @@ class RoundRobin(MonitorStrategy):
         self._last_worker = -1
 
     def update_node(self, updated):
-        for worker_id in updated.sub_resources['workers'].keys():
+
+        # Stale worker eviction (replacement may join before heartbeat timeout)
+        node_idx = int(updated.uid.split(':')[1])
+        incoming = set(updated.sub_resources.get('workers', {}).keys())
+        prefix = f'worker:{node_idx}'
+        stale = {w for w in self._worker_list if w.startswith(prefix) and w not in incoming}
+
+        if stale:
+            self._worker_list -= stale
+            self._num_workers = len(self._worker_list)
+            self._monitor.logger.debug(f'Evicted stale workers: {stale}')
+
+        before = set(self._worker_list)
+        for worker_id in incoming:
             self._worker_list.add(worker_id)
 
         self._num_workers = len(self._worker_list)
+
+        new_workers = self._worker_list - before
+        if new_workers:
+            self._monitor.logger.debug(
+                f'New workers added: {new_workers} '
+                f"(pool now: {sorted(self._worker_list)}"
+            )
 
     def select_worker(self, sender_id):
         self._last_worker = (self._last_worker + 1) % self._num_workers

--- a/mosaic/runtime/warehouse.py
+++ b/mosaic/runtime/warehouse.py
@@ -54,7 +54,7 @@ class Warehouse(Runtime):
         warehouse_memory = memory_limit() * warehouse_memory_fraction
 
         self._local_warehouse = SpillBuffer(self._spill_directory, warehouse_memory)
-    
+
     @staticmethod
     def _warehouse_uid_from_node(node):
         """Derive the warehouse UID from the node."""

--- a/mosaic/runtime/warehouse.py
+++ b/mosaic/runtime/warehouse.py
@@ -54,6 +54,11 @@ class Warehouse(Runtime):
         warehouse_memory = memory_limit() * warehouse_memory_fraction
 
         self._local_warehouse = SpillBuffer(self._spill_directory, warehouse_memory)
+    
+    @staticmethod
+    def _warehouse_uid_from_node(node):
+        """Derive the warehouse UID from the node."""
+        return f'warehouse:{node.uid[len("node:"):]}'
 
     def set_logger(self):
         """
@@ -273,9 +278,9 @@ class Warehouse(Runtime):
             tasks = []
 
             for node in self._nodes.values():
-                if node.uid not in self._warehouses:
-                    self._warehouses[node.uid] = self.proxy('warehouse',
-                                                            indices=node.indices[0])
+                warehouse_uid = self._warehouse_uid_from_node(node)
+                if node.uid not in self._warehouses or self._warehouses[node.uid].uid != warehouse_uid:
+                    self._warehouses[node.uid] = self.proxy('warehouse', uid=warehouse_uid)
                 tasks.append(self._warehouses[node.uid].push_remote(__dict__=__dict__, uid=uid, reply=True))
 
             if len(self.indices):
@@ -365,9 +370,9 @@ class Warehouse(Runtime):
         tasks = []
 
         for node in self._nodes.values():
-            if node.uid not in self._warehouses:
-                self._warehouses[node.uid] = self.proxy('warehouse',
-                                                        indices=node.indices[0])
+            warehouse_uid = self._warehouse_uid_from_node(node)
+            if node.uid not in self._warehouses or self._warehouses[node.uid].uid != warehouse_uid:
+                self._warehouses[node.uid] = self.proxy('warehouse', uid=warehouse_uid)
             tasks.append(self._warehouses[node.uid].put_remote(obj=obj, uid=obj_id, reply=True))
 
         if len(self.indices):

--- a/mosaic/runtime/warehouse.py
+++ b/mosaic/runtime/warehouse.py
@@ -60,6 +60,14 @@ class Warehouse(Runtime):
         """Derive the warehouse UID from the node."""
         return f'warehouse:{node.uid[len("node:"):]}'
 
+    def _ensure_warehouse_proxy(self, node):
+        """Return a proxy to the given node's warehouse, refreshing if its UID changed."""
+        warehouse_uid = self._warehouse_uid_from_node(node)
+        if (node.uid not in self._warehouses
+                or self._warehouses[node.uid].uid != warehouse_uid):
+            self._warehouses[node.uid] = self.proxy('warehouse', uid=warehouse_uid)
+        return self._warehouses[node.uid]
+
     def set_logger(self):
         """
         Set up logging.
@@ -278,10 +286,8 @@ class Warehouse(Runtime):
             tasks = []
 
             for node in self._nodes.values():
-                warehouse_uid = self._warehouse_uid_from_node(node)
-                if node.uid not in self._warehouses or self._warehouses[node.uid].uid != warehouse_uid:
-                    self._warehouses[node.uid] = self.proxy('warehouse', uid=warehouse_uid)
-                tasks.append(self._warehouses[node.uid].push_remote(__dict__=__dict__, uid=uid, reply=True))
+                proxy = self._ensure_warehouse_proxy(node)
+                tasks.append(proxy.push_remote(__dict__=__dict__, uid=uid, reply=True))
 
             if len(self.indices):
                 if 'head' not in self._warehouses:
@@ -370,10 +376,8 @@ class Warehouse(Runtime):
         tasks = []
 
         for node in self._nodes.values():
-            warehouse_uid = self._warehouse_uid_from_node(node)
-            if node.uid not in self._warehouses or self._warehouses[node.uid].uid != warehouse_uid:
-                self._warehouses[node.uid] = self.proxy('warehouse', uid=warehouse_uid)
-            tasks.append(self._warehouses[node.uid].put_remote(obj=obj, uid=obj_id, reply=True))
+            proxy = self._ensure_warehouse_proxy(node)
+            tasks.append(proxy.put_remote(obj=obj, uid=obj_id, reply=True))
 
         if len(self.indices):
             if 'head' not in self._warehouses:

--- a/mosaic/types/warehouse_object.py
+++ b/mosaic/types/warehouse_object.py
@@ -30,8 +30,12 @@ class WarehouseObject:
             self._uid = uid
 
         runtime = self.runtime
-        if 'worker' in runtime.uid:
-            node_id = 'node:%d' % runtime.indices[0]
+        if runtime.uid.startswith('worker'):
+            parts = runtime.uid.split(':')
+            if len(parts) >= 4:
+                node_id = f'node:{parts[1]}:{parts[3]}'
+            else:
+                node_id = f'node:{parts[1]}'
         else:
             node_id = runtime.uid
 


### PR DESCRIPTION
**This PR has two main features:**

1) Inverts the node registration model so the monitor no longer has to spawns nodes. Instead, the monitor starts in dynamic mode (`--dynamic`) and nodes phone home (`--phone-home`) by reading the monitor's address from environment variables. This enables cloud deployments where pods are scheduled independently by Kubernetes/Argo.

2) Each node generates a per-boot instance ID (8-char hex) appended to every UID (`node:0:a3f7b2c1`, `worker:0:0:a3f7b2c1`, `warehouse:0:a3f7b2c1`). A node, its workers, and its warehouse share the same instance ID. This eliminates UID collisions when a pod is replaced at the same index.

**Changes:**

* UID scheme: `BaseRPC` parses instance IDs via `_uid_override`, backwards compatible with legacy UIDs
* Phone-home mode: nodes read MONITOR_HOST/MONITOR_PORT/PUBSUB_PORT from env vars
* Dynamic mode: `Monitor.init_dynamic()` waits for nodes instead of spawning them. `register_node()` RPC accepts new nodes and starts heartbeat monitoring
* Comms: address auto-detection via UDP probe (for K8s where 0.0.0.0 isn't routable), reconnection on address change, handshake buffering to prevent lost RPCs during connection setup
* Warehouse routing: `_warehouse_uid_for_node()` derives warehouse UID from node UID. `WarehouseObject` derives node UID from worker UID with instance ID
* Strategy: `RoundRobin.update_node()` evicts stale workers when a replacement node joins


**Changes based on feedback:**

* Unified `--dynamic` and `--phone-home` into a single `--dynamic` flag.
* Renamed env vars
* Added `BaseRPC.instance_id` kwarg + `_build_uid` static helper. 
* Extracted `discover_routable_address()` shared by `InboundConnection.address` and `Publication.address`, restored main branch hostname-first order while keeping the 0.0.0.0 K8s auto-detect.
* Added `_ensure_warehouse_proxy()` helper to de-duplicate the per-node warehouse proxy refresh.
* Dropped `Node._warehouse_uid` reads from inherited `self._local_warehouse.uid`.
* Hoisted `start_worker` closure values into locals so the subprocess no longer pickles self.

**Still open:** 
* `Head.wait_for_workers` partial-acceptance / cloud timeout (potentially `num_workers` ideal + `min_workers` floor)
